### PR TITLE
fix: missing label prometheus

### DIFF
--- a/.changeset/real-pumas-cough.md
+++ b/.changeset/real-pumas-cough.md
@@ -1,0 +1,5 @@
+---
+'stream-collector': patch
+---
+
+Added missing label prometheus

--- a/apps/stream-collector/src/census/modules/metric.module.ts
+++ b/apps/stream-collector/src/census/modules/metric.module.ts
@@ -48,7 +48,7 @@ import {
     makeCounterProvider({
       name: essSubscriptionAlterationCount,
       help: 'Counter that tracks how many times a subscription to a connection has been altered',
-      labelNames: ['connection'],
+      labelNames: ['connection', 'key'],
     }),
     makeCounterProvider({
       name: essSubscriptionMessageTimeoutCount,


### PR DESCRIPTION
Missing label would cause a crash when the counter would be incremented.